### PR TITLE
Fix timeout issue that played hourly music after playing one KK song

### DIFF
--- a/scripts/AudioManager.js
+++ b/scripts/AudioManager.js
@@ -91,6 +91,7 @@ function AudioManager(addEventListener, isTownTune) {
 		kkVersion = _kkVersion;
 		clearLoop();
 		audio.loop = false;
+		audio.onplay = null
 		audio.addEventListener("ended", playKKSong);
 		fadeOutAudio(500, playKKSong);
 
@@ -112,6 +113,7 @@ function AudioManager(addEventListener, isTownTune) {
 
 		let formattedTitle = `${randomSong.split(' - ')[1]} (${version.charAt(0).toUpperCase() + version.slice(1)} Version)`;
 		window.notify("kkMusic", [formattedTitle]);
+
 		mediaSessionManager.updateMetadataKK(formattedTitle, randomSong);
 	}
 


### PR DESCRIPTION
This is a very **tiny** PR. 

As no issue was created for this I'm pasting what I reported on the Discord channel to give some context:

> Yeah, the audio.onplay callback on AudioManager.js:67 sets up loopTimeout for hourly music and for some reason the killLoopTimeout does not actually clear this timeout

> It can be reproduced by starting music, choosing Do Not Play KK (this sets up hourly music and the timeout) then immediately selecting Play KK Songs (which doesn't correctly clear the timeout). When the first KK song ends, hourly music restarts

> Sorry it does clear the timeout correctly, but audio.onplay callback never gets cleared so next KK song will again set new timeout which will play hourly music

A `audio.onplay` callback that calls `playHourlyMusic()` is set whevener hourly music is selected.
If you select hourly music first then KK music, this didn't get cleared so it got called too, which made hourly music play eventually. 



Tried setting `audio.onplay` to null when KK music is selected and now it seems that it works as expected.

