### PR TITLE
Update K.K. Slider Option Logic

### DIFF
--- a/options.html
+++ b/options.html
@@ -48,7 +48,7 @@
 						</div>
 					</section>
 
-					<section>
+					<section id="music-selection">
 						<h3>Music</h3>
 						<div class="radio">
 							<input id="animal-crossing" name="music-choice" type="radio"><label for="animal-crossing"><span><span></span></span>Animal Forest/Animal Crossing</label>
@@ -95,16 +95,19 @@
 						<div class="radio">
 							<input id="always-kk" name="enable-kk" type="radio"><label for="always-kk"><span><span></span></span>Play K.K. Slider songs at all times</label>
 						</div>
-						<h4>K.K. Slider - Version Choice</h4>
-						<div class="radio">
-							<input id="kk-version-live" name="kk-version" type="radio"><label for="kk-version-live"><span><span></span></span>Live</label>
-						</div>
-						<div class="radio">
-							<input id="kk-version-aircheck" name="kk-version" type="radio"><label for="kk-version-aircheck"><span><span></span></span>Aircheck</label>
-						</div>
-						<div class="radio">
-							<input id="kk-version-both" name="kk-version" type="radio"><label for="kk-version-both"><span><span></span></span>Both</label>
-						</div>
+						
+						<section id="kk-version-selection">
+							<h4>K.K. Slider - Version Choice</h4>
+							<div class="radio">
+								<input id="kk-version-live" name="kk-version" type="radio"><label for="kk-version-live"><span><span></span></span>Live</label>
+							</div>
+							<div class="radio">
+								<input id="kk-version-aircheck" name="kk-version" type="radio"><label for="kk-version-aircheck"><span><span></span></span>Aircheck</label>
+							</div>
+							<div class="radio">
+								<input id="kk-version-both" name="kk-version" type="radio"><label for="kk-version-both"><span><span></span></span>Both</label>
+							</div>
+						</section>
 					</section>
 
 					<section>

--- a/scripts/options.js
+++ b/scripts/options.js
@@ -32,10 +32,10 @@ function saveOptions() {
 	document.getElementById('raining').disabled = music == 'animal-crossing';
 
 	let enabledKKVersion = !(document.getElementById('always-kk').checked || document.getElementById('enable-kk').checked);
-	document.getElementById('kk-version-live').disabled = enabledKKVersion;
-	document.getElementById('kk-version-aircheck').disabled = enabledKKVersion;
-	document.getElementById('kk-version-both').disabled = enabledKKVersion;
 
+	document.getElementById('music-selection').querySelectorAll('input').forEach(updateChildrenState.bind(null, alwaysKK));
+	document.getElementById('kk-version-selection').querySelectorAll('input').forEach(updateChildrenState.bind(null, enabledKKVersion));
+	
 	chrome.storage.sync.set({
 		volume,
 		music,
@@ -51,6 +51,9 @@ function saveOptions() {
 	});
 }
 
+function updateChildrenState(disabled, childElement){		
+	childElement.disabled = disabled
+}
 function restoreOptions() {
 	chrome.storage.sync.get({
 		volume: 0.5,
@@ -82,9 +85,8 @@ function restoreOptions() {
 		document.getElementById('raining').disabled = items.music == 'animal-crossing';
 
 		let enabledKKVersion = !(document.getElementById('always-kk').checked || document.getElementById('enable-kk').checked);
-		document.getElementById('kk-version-live').disabled = enabledKKVersion;
-		document.getElementById('kk-version-aircheck').disabled = enabledKKVersion;
-		document.getElementById('kk-version-both').disabled = enabledKKVersion;
+		document.getElementById('kk-version-selection').querySelectorAll('input').forEach(updateChildrenState.bind(null, enabledKKVersion));
+		document.getElementById('music-selection').querySelectorAll('input').forEach(updateChildrenState.bind(null, items.alwaysKK));
 	});
 }
 


### PR DESCRIPTION
When `Play K.K. Slider songs at all times` option is on, ac music can still be changed and will play when changed. Disabling the ability to change it is an easier fix than touching the StateManager. Refactored disable logic a teeny bit.