### PR TITLE
Fix K.K. slider override

### DIFF
--- a/scripts/StateManager.js
+++ b/scripts/StateManager.js
@@ -149,7 +149,7 @@ function StateManager() {
 			if (typeof changes.zipCode !== 'undefined') weatherManager.setZip(options.zipCode);
 			if (typeof changes.countryCode !== 'undefined') weatherManager.setCountry(options.countryCode);
 			if (typeof changes.volume !== 'undefined') notifyListeners("volume", [options.volume]);
-			if (typeof changes.music !== 'undefined' || typeof changes.weather && !isKK()) {
+			if ((typeof changes.music !== 'undefined' || typeof changes.weather) && !isKK()) {
 				let musicAndWeather = getMusicAndWeather();
 				if (musicAndWeather.music != oldMusicAndWeather.music || musicAndWeather.weather != oldMusicAndWeather.weather)
 					notifyListeners("gameChange", [timeKeeper.getHour(), musicAndWeather.weather, musicAndWeather.music]);


### PR DESCRIPTION
Fixes the bug that causes the music to forcibly change if a user changes the `Music` or `Weather` option while K.K. is playing, which puts the extension into an invalid state.