### PR TITLE
Weather revamp

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -36,7 +36,7 @@
    "permissions": [
       "notifications",
       "storage",
-      "http://api.openweathermap.org/"
+      "https://ac.pikadude.me/"
    ],
    "update_url": "https://clients2.google.com/service/update2/crx",
    "version": "4.0"

--- a/scripts/background/AudioManager.js
+++ b/scripts/background/AudioManager.js
@@ -155,6 +155,8 @@ function AudioManager(addEventListener, isTownTune) {
 
 	addEventListener("gameChange", playHourlyMusic);
 
+	addEventListener("weatherChange", playHourlyMusic);
+
 	addEventListener("pause", () => {
 		clearLoop();
 		fadeOutAudio(300);

--- a/scripts/background/BadgeManager.js
+++ b/scripts/background/BadgeManager.js
@@ -24,11 +24,9 @@ function BadgeManager(addEventListener, isEnabled) {
 		setIcon('paused');
 	});
 
-	addEventListener("gameChange", (hour, weather) => {
-		setIcon(weather);
-	});
+	addEventListener("gameChange", (hour, weather) => setIcon(weather));
 
-	addEventListener("weatherChange", setIcon);
+	addEventListener("weatherChange", (hour, weather) => setIcon(weather));
 
 	chrome.browserAction.setBadgeBackgroundColor({ color: [57, 230, 0, 255] });
 

--- a/scripts/background/NotificationManager.js
+++ b/scripts/background/NotificationManager.js
@@ -13,7 +13,7 @@ function NotificationManager(addEventListener, isEnabled) {
 		});
 	}
 
-	addEventListener("weatherChange", weather => {
+	addEventListener("weatherChange", (hour, weather) => {
 		isEnabled() && doNotification("It is now " + weather.toLowerCase());
 	});
 

--- a/scripts/background/WeatherManager.js
+++ b/scripts/background/WeatherManager.js
@@ -3,81 +3,71 @@
 'use strict';
 
 function WeatherManager(zip, country) {
-	var self = this;
+	let self = this;
 
-	var timeout;
-	var callback;
+	let timeout;
+	let callback;
 
-	var weather;
-	var checked = false;
+	let weather;
 
-	var weatherRain = ['Thunderstorm', 'Drizzle', 'Rain', 'Mist'];
- 	var weatherSnow = ['Snow', 'Fog'];
-
-	this.registerChangeCallback = function(cb) {
+	this.registerChangeCallback = function (cb) {
 		callback = cb;
 	};
 
-	this.setZip = function(newZip) {
+	this.setZip = function (newZip) {
 		zip = newZip;
-		restartCheckLoop();
 	};
 
-	this.setCountry = function(newCountry) {
+	this.setCountry = function (newCountry) {
 		country = newCountry;
 		restartCheckLoop();
 	};
 
-	this.getWeather = function() {
-		if (!checked) return "Unknown";
-
-		if(~weatherRain.indexOf(weather)) {
-			return "Rain";
-		} else if(~weatherSnow.indexOf(weather)) {
-			return "Snow";
-		} else {
-			return "Clear";
-		}
+	this.getWeather = function () {
+		return weather;
 	};
 
 	// Checks the weather, and restarts the loop
 	function restartCheckLoop() {
-		if(timeout) clearTimeout(timeout);
+		if (timeout) clearTimeout(timeout);
 		timeout = null;
 		weatherCheckLoop();
 	}
-	
+
 	// Checks the weather every 10 minutes, calls callback if it's changed
-	var weatherCheckLoop = function() {
-		//if appid is not valid nothing will be returned
-	 	var appid = "e7f97bd1900b94491d3263f89cbe28d6";
-	 	var url = `http://api.openweathermap.org/data/2.5/weather?zip=${zip},${country}&appid=${appid}`
-	 
-	 	var request = new XMLHttpRequest();
-	 
-	 	request.onreadystatechange = function() {
- 			if(request.readyState == 4 && request.status == 200) {
-				checked = true;
- 				var response = JSON.parse(request.responseText);
- 				if( response.cod == "200" && response.weather[0].main !== weather) {
-					var oldWeather = self.getWeather();
- 					weather = response.weather[0].main;
- 					if(self.getWeather() !== oldWeather && typeof callback === 'function' ) {
- 						callback();
- 					}
- 				}
- 			}
- 		}
-	 
-	 	request.open("GET", url, true);
-	 	request.send();
-	 	timeout = setTimeout(weatherCheckLoop, 600000);
+	let weatherCheckLoop = function () {
+		let url = `https://ac.pikadude.me/weather/${country}/${zip}`
+		let request = new XMLHttpRequest();
+
+		request.onload = function () {
+			if (request.status == 200 || request.status == 304) {
+				let response = JSON.parse(request.responseText);
+				if (response.weather !== weather) {
+					let oldWeather = self.getWeather();
+					weather = response.weather;
+					if (weather !== oldWeather && typeof callback === 'function') callback();
+				}
+			} else err();
+		}
+
+		request.onerror = err;
+
+		function err() {
+			if (!weather) {
+				weather = "Clear";
+				callback();
+			}
+		}
+
+		request.open("GET", url, true);
+		request.send();
+		timeout = setTimeout(weatherCheckLoop, 600000);
 	};
 
 	weatherCheckLoop();
-	
-	if(DEBUG_FLAG) {
-		window.changeWeather = function(newWeather) {
+
+	if (DEBUG_FLAG) {
+		window.changeWeather = function (newWeather) {
 			weather = newWeather;
 			callback();
 		}

--- a/scripts/options/options.js
+++ b/scripts/options/options.js
@@ -151,10 +151,8 @@ function validateWeather() {
 			return;
 		}
 
-		if (request.status == 200) {
-			responseMessage(`Success! The current weather status in ${response.city}, ${response.country} is "${response.weather}"`, true);
-			saveOptions();
-		} else {
+		if (request.status == 200) responseMessage(`Success! The current weather status in ${response.city}, ${response.country} is "${response.weather}"`, true);
+		else {
 			if (response.error) responseMessage(response.error);
 			else responseMessage();
 		}

--- a/scripts/options/options.js
+++ b/scripts/options/options.js
@@ -139,8 +139,7 @@ function validateWeather() {
 		return;
 	}
 
-	let appid = "e7f97bd1900b94491d3263f89cbe28d6";
-	let url = `http://api.openweathermap.org/data/2.5/weather?zip=${zip},${country}&appid=${appid}`;
+	let url = `https://ac.pikadude.me/weather/${country}/${zip}`;
 	let request = new XMLHttpRequest();
 
 	request.onload = function () {
@@ -152,14 +151,16 @@ function validateWeather() {
 			return;
 		}
 
-		if (response.cod == "200") responseMessage(`Success! The current weather status in ${response.name}, ${response.sys.country} is "${response.weather[0].main}"`, true);
-		else {
-			if (response.message) responseMessage(response.message.charAt(0).toUpperCase() + response.message.slice(1));
+		if (request.status == 200) {
+			responseMessage(`Success! The current weather status in ${response.city}, ${response.country} is "${response.weather}"`, true);
+			saveOptions();
+		} else {
+			if (response.error) responseMessage(response.error);
 			else responseMessage();
 		}
 	}
 
-	request.onerror = responseMessage;
+	request.onerror = () => responseMessage();
 
 	request.open("GET", url, true);
 	request.send();


### PR DESCRIPTION
This PR introduces:
- Updated the URL to use a custom webserver that I made that now handles all weather requests. This webserver is effectively used as a proxy, only returning the necessary data and hiding the api keys, also caching results for a few minutes to prevent spam to the openweathermap api and to avoid hitting the ratelimit. This solution will also help us see if we are hitting the openweathermap api, as with the previous solution it was not possible.
- Live weather now works offline. If a request fails, it will simply use the previous weather, or if there was no previous weather it will simply default to clear/sunny.
- Actually sends weather change events. This was removed prior on accident.
- Some minor refactoring.