### PR TITLE
Add: option to play town tune if music is paused

### DIFF
--- a/css/chrome-bootstrap.css
+++ b/css/chrome-bootstrap.css
@@ -546,7 +546,7 @@
 
   background-image: -webkit-image-set(url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABMAAAAICAYAAAAbQcSUAAAAAXNSR0IArs4c6QAAAAd0SU1FB9sLAxYEBKriBmwAAAAGYktHRAD/AP8A/6C9p5MAAAAJcEhZcwAACxMAAAsTAQCanBgAAABLSURBVCiRY2CgA4gC4jQ8OIpokxKBoKGh4T8uDJIn2rD///8rLFiwYCE2g0DiIHkSfIndQLIMwmYgRQYhG/j27dsmig1CMpCVGHUAo8FcsHfxfXQAAAAASUVORK5CYII=") 1 x), -webkit-linear-gradient(#f1f1f1, #f1f1f1 38%, #e6e6e6);
 }
-.chrome-bootstrap input[type='checkbox']:disabled,
+.chrome-bootstrap input[type='checkbox']:disabled + label,
 .chrome-bootstrap input[type='radio']:disabled + label {
   opacity: .5;
 }

--- a/options.html
+++ b/options.html
@@ -118,6 +118,9 @@
 						<div class="checkbox">
 							<input id="enable-town-tune" type="checkbox"><label for="enable-town-tune"><span></span>Play your custom town tune on the hour</label>
 						</div>
+						<div class="checkbox">
+							<input id="absolute-town-tune" type="checkbox"><label for="absolute-town-tune"><span></span>Play your custom town tune regardless if the music is paused</label>
+						</div>
 					</section>
 
 					<section>

--- a/scripts/background/StateManager.js
+++ b/scripts/background/StateManager.js
@@ -11,6 +11,7 @@ function StateManager() {
 	let callbacks = {};
 
 	let timeKeeper = new TimeKeeper();
+	let townTuneManager = new TownTuneManager();
 	let weatherManager;
 	let isKKTime;
 	let startup = true;
@@ -84,6 +85,7 @@ function StateManager() {
 			kkVersion: 'live',
 			paused: false,
 			enableTownTune: true,
+			absoluteTownTune: false,
 			//enableAutoPause: false,
 			zipCode: "98052",
 			countryCode: "us",
@@ -143,6 +145,8 @@ function StateManager() {
 		else if (!isKK()) {
 			let musicAndWeather = getMusicAndWeather();
 			notifyListeners("hourMusic", [hour, musicAndWeather.weather, musicAndWeather.music, true]);
+
+			if (options.paused && options.absoluteTownTune) townTuneManager.playTune();
 		}
 	});
 

--- a/scripts/global/tune_player.js
+++ b/scripts/global/tune_player.js
@@ -181,7 +181,7 @@ var createTunePlayer = function(audioContext, bpm) {
       },
       done: function(callback) {
         //when the tune over
-        setTimeout(callback, stepDuration * tune.length * 1000);
+        if (callback) setTimeout(callback, stepDuration * tune.length * 1000);
         return callbacks;
       }
     };

--- a/scripts/options/options.js
+++ b/scripts/options/options.js
@@ -67,6 +67,7 @@ function saveOptions() {
 	else if (document.getElementById('kk-version-both').checked) kkVersion = 'both';
 
 	document.getElementById('raining').disabled = music == 'animal-crossing';
+	document.getElementById('absolute-town-tune').disabled = !enableTownTune;
 
 	let enabledKKVersion = !(document.getElementById('always-kk').checked || document.getElementById('enable-kk').checked);
 	document.getElementById('kk-version-live').disabled = enabledKKVersion;
@@ -120,6 +121,7 @@ function restoreOptions() {
 
 		// Disable raining if the game is animal crossing, since there is no raining music for animal crossing.
 		document.getElementById('raining').disabled = items.music == 'animal-crossing';
+		document.getElementById('absolute-town-tune').disabled = !items.enableTownTune;
 
 		let enabledKKVersion = !(document.getElementById('always-kk').checked || document.getElementById('enable-kk').checked);
 		document.getElementById('kk-version-live').disabled = enabledKKVersion;

--- a/scripts/options/options.js
+++ b/scripts/options/options.js
@@ -14,6 +14,7 @@ const onClickElements = [
 	'enable-kk',
 	'always-kk',
 	'enable-town-tune',
+	'absolute-town-tune',
 	'enable-notifications',
 	'enable-badge',
 	'kk-version-live',
@@ -42,6 +43,7 @@ function saveOptions() {
 	let alwaysKK = document.getElementById('always-kk').checked;
 	let enableKK = alwaysKK || document.getElementById('enable-kk').checked;
 	let enableTownTune = document.getElementById('enable-town-tune').checked;
+	let absoluteTownTune = document.getElementById('absolute-town-tune').checked;
 	let zipCode = document.getElementById('zip-code').value;
 	let countryCode = document.getElementById('country-code').value;
 	let enableBadgeText = document.getElementById('enable-badge').checked;
@@ -80,6 +82,7 @@ function saveOptions() {
 		alwaysKK,
 		kkVersion,
 		enableTownTune,
+		absoluteTownTune,
 		zipCode,
 		countryCode,
 		enableBadgeText
@@ -96,6 +99,7 @@ function restoreOptions() {
 		alwaysKK: false,
 		kkVersion: 'live',
 		enableTownTune: true,
+		absoluteTownTune: false,
 		zipCode: "98052",
 		countryCode: "us",
 		enableBadgeText: true
@@ -109,6 +113,7 @@ function restoreOptions() {
 		document.getElementById('always-kk').checked = items.alwaysKK;
 		document.getElementById('kk-version-' + items.kkVersion).checked = true;
 		document.getElementById('enable-town-tune').checked = items.enableTownTune;
+		document.getElementById('absolute-town-tune').checked = items.absoluteTownTune;
 		document.getElementById('zip-code').value = items.zipCode;
 		document.getElementById('country-code').value = items.countryCode;
 		document.getElementById('enable-badge').checked = items.enableBadgeText;


### PR DESCRIPTION
Adds a simple checkbox in options that allows the town tune to play regardless if the extension's music is not playing/paused.
![image](https://user-images.githubusercontent.com/18642415/72888146-216af080-3d61-11ea-972f-abc52284fa01.png)


Closes animal-crossing-music-extension/Animal-Crossing-Music-Extension#32