### PR TITLE
Only update volume option when slider is released

### DIFF
--- a/scripts/options/options.js
+++ b/scripts/options/options.js
@@ -38,7 +38,7 @@ window.onload = function () {
 
 	document.getElementById('version-number').textContent = 'Version ' + chrome.runtime.getManifest().version;
 
-	document.getElementById('volume').oninput = saveOptions;
+	document.getElementById('volume').onchange = saveOptions;
 	onClickElements.forEach(el => {
 		document.getElementById(el).onclick = saveOptions;
 	});


### PR DESCRIPTION
Would close #41 

**Trivial PR**: Replace volume `oninput` callback for `onchange`, which only triggers when the slider is released. See issue for more context. 