### PR TITLE
Show volume slider value

### DIFF
--- a/options.html
+++ b/options.html
@@ -53,11 +53,12 @@
 					<section>
 						<h3>Volume</h3>
 						<p>Adjust the volume that the extension's music plays at</p>
-						<div class="checkbox">
+						<span class="checkbox">
 							<label>
 								<input aria-label="Volume" id="volume" type="range" min="0" max="1" step="0.01">
 							</label>
-						</div>
+						</span>
+						<span id="volumeText"></span>
 					</section>
 
 					<section>

--- a/scripts/options/options.js
+++ b/scripts/options/options.js
@@ -44,10 +44,13 @@ function formatPercentage(number) {
 
 window.onload = function () {
 	restoreOptions();
-
 	document.getElementById('version-number').textContent = 'Version ' + chrome.runtime.getManifest().version;
-
 	document.getElementById('volume').onchange = saveOptions;
+	document.getElementById('volume').oninput = function() {
+		let volumeText = document.getElementById('volumeText');
+		volumeText.innerHTML = `${formatPercentage(this.value*100)}`;
+	};
+
 	onClickElements.forEach(el => {
 		document.getElementById(el).onclick = saveOptions;
 	});
@@ -176,6 +179,7 @@ function restoreOptions() {
 		tabAudioReduceValue: 80
 	}, items => {
 		document.getElementById('volume').value = items.volume;
+		document.getElementById('volumeText').innerHTML = `${formatPercentage(items.volume*100)}`;
 		document.getElementById(items.music).checked = true;
 		document.getElementById(items.weather).checked = true;
 		document.getElementById('enable-notifications').checked = items.enableNotifications;

--- a/scripts/options/options.js
+++ b/scripts/options/options.js
@@ -33,6 +33,15 @@ const exclamationElements = [
 	'town-tune-button-link'
 ]
 
+// Formats an integer to percentage
+function formatPercentage(number) {
+	number = parseInt(number)
+	if (number <= 0) return '0%'
+	else if (number >= 100) return '100%'
+	else if (number < 10) return `0${number}%`
+	else return `${number}%`
+}
+
 window.onload = function () {
 	restoreOptions();
 


### PR DESCRIPTION
While working on #42 I thought it would be nice to actually see the volume value when moving the slider.

**TL;DR:** 
<img width="360" alt="Screenshot 2020-01-26 at 00 04 57" src="https://user-images.githubusercontent.com/16718039/73128430-83309200-3fcf-11ea-8c1c-912db5f983d5.png">

Feel free to add commits to this PR if you want to customize the UI