### PR TITLE
Fix: ignoring tabaudio on hour change

### DIFF
--- a/scripts/background/AudioManager.js
+++ b/scripts/background/AudioManager.js
@@ -91,6 +91,7 @@ function AudioManager(addEventListener, isTownTune) {
 		};
 
 		if (!tabAudioPaused) audio.play().then(setLoopTimes);
+		else window.notify("pause", [tabAudioPaused]); // Set the badge icon back to the paused state
 
 		function setLoopTimes() {
 			// song has started

--- a/scripts/background/AudioManager.js
+++ b/scripts/background/AudioManager.js
@@ -90,7 +90,7 @@ function AudioManager(addEventListener, isTownTune) {
 			}
 		};
 
-		audio.play().then(setLoopTimes);
+		if (!tabAudioPaused) audio.play().then(setLoopTimes);
 
 		function setLoopTimes() {
 			// song has started

--- a/scripts/background/BadgeManager.js
+++ b/scripts/background/BadgeManager.js
@@ -18,9 +18,11 @@ function BadgeManager(addEventListener, isEnabledStart) {
 	}
 
 	addEventListener("hourMusic", (hour, weather) => {
-		badgeText = `${formatHour(hour)}`;
-		if (isEnabled) updateBadgeText();
-		setIcon(weather);
+		if (!isTabAudible) {
+			badgeText = `${formatHour(hour)}`;
+			if (isEnabled) updateBadgeText();
+			setIcon(weather);
+		}
 	});
 
 	addEventListener("kkStart", () => {


### PR DESCRIPTION
This PR fixes a bug that caused the music to forcibly start playing, if the option to pause music while a tab was playing audio was selected and a tab was playing audio.